### PR TITLE
Hide __InvalidState__ in generated doc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ macro_rules! microstate (
       pub mod $machine {
           #[derive(Clone,PartialEq,Eq,Debug)]
           pub enum State {
+              #[doc(hidden)]
               __InvalidState__, // Just be able to match _ further down
               $($states),*
           }


### PR DESCRIPTION
As it's a variant which should not be used (only for keeping rustc happy), I think it's better to keep it hidden in generated doc.
